### PR TITLE
Add iam identity center modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,26 @@ Some examples:
 - `webappdb.rds.company.local`
 - `products.opensearch.company.local`
 - `bastion.ec2.company.local`
+
+## Useful commands
+
+## Terraform docs
+Run the following command from the module root to automatically create terraform documentation:
+
+```terraform-docs markdown --output-file README.md --output-mode inject .```
+
+## Terraform code formatting
+
+Run the following command from the project root (or module root) to format your code format nicely:
+
+```terraform fmt -recursive```
+
+This is a requirement for every pull request.
+
+## Terraform code validation
+
+Run the following command from the /modules folder to validate your terraform to best practices:
+
+```tflint --init && tflint --recursive --config ".tflint.hcl"```
+
+This is a requirement for every pull request.

--- a/examples/iam-identity-center/main.tf
+++ b/examples/iam-identity-center/main.tf
@@ -1,0 +1,34 @@
+
+module "engineer_group" {
+  source       = "../../modules/iam-identity-center/iam-identity-center-group/v0.0.1"
+  display_name = "engineer"
+  description  = "All engineers will be in this group"
+}
+
+module "john_doe" {
+  source      = "../../modules/iam-identity-center/iam-identity-center-user/v0.0.1"
+  email       = "john@email.com"
+  given_name  = "John"
+  family_name = "Doe"
+  groups = {
+    engineer = module.engineer_group.group_id
+  }
+}
+
+module "power_user_permission_set" {
+  source      = "../../modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1"
+  name        = "power-user-access"
+  description = "permission set for power user access"
+  managed_policy_arns = {
+    power_user = "arn:aws:iam::aws:policy/PowerUserAccess"
+  }
+}
+
+module "engineer_power_user_assignment" {
+  source             = "../../modules/iam-identity-center/iam-identity-center-group-assignment/v0.0.1"
+  permission_set_arn = module.power_user_permission_set.permission_set_arn
+  group_id           = module.engineer_group.group_id
+  account_ids = {
+    management = "909183324734" #devorg-management account id
+  }
+}

--- a/modules/iam-identity-center/iam-identity-center-group-assignment/v0.0.1/README.md
+++ b/modules/iam-identity-center/iam-identity-center-group-assignment/v0.0.1/README.md
@@ -1,0 +1,37 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ssoadmin_account_assignment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_account_assignment) | resource |
+| [aws_ssoadmin_instances.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | The account ids scoped for the assignment | `map(string)` | n/a | yes |
+| <a name="input_group_id"></a> [group\_id](#input\_group\_id) | The id of the group to be assigned to the account ids | `string` | n/a | yes |
+| <a name="input_permission_set_arn"></a> [permission\_set\_arn](#input\_permission\_set\_arn) | The arn of the permission set to be assigned to the account ids | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/iam-identity-center/iam-identity-center-group-assignment/v0.0.1/main.tf
+++ b/modules/iam-identity-center/iam-identity-center-group-assignment/v0.0.1/main.tf
@@ -1,0 +1,13 @@
+data "aws_ssoadmin_instances" "this" {}
+
+resource "aws_ssoadmin_account_assignment" "this" {
+  for_each           = var.account_ids
+  instance_arn       = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+  permission_set_arn = var.permission_set_arn
+
+  principal_id   = var.group_id
+  principal_type = "GROUP"
+
+  target_id   = each.value
+  target_type = "AWS_ACCOUNT"
+}

--- a/modules/iam-identity-center/iam-identity-center-group-assignment/v0.0.1/provider.tf
+++ b/modules/iam-identity-center/iam-identity-center-group-assignment/v0.0.1/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/iam-identity-center/iam-identity-center-group-assignment/v0.0.1/variables.tf
+++ b/modules/iam-identity-center/iam-identity-center-group-assignment/v0.0.1/variables.tf
@@ -1,0 +1,14 @@
+variable "permission_set_arn" {
+  description = "The arn of the permission set to be assigned to the account ids"
+  type        = string
+}
+
+variable "group_id" {
+  description = "The id of the group to be assigned to the account ids"
+  type        = string
+}
+
+variable "account_ids" {
+  description = "The account ids scoped for the assignment"
+  type        = map(string)
+}

--- a/modules/iam-identity-center/iam-identity-center-group/v0.0.1/README.md
+++ b/modules/iam-identity-center/iam-identity-center-group/v0.0.1/README.md
@@ -1,0 +1,38 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_identitystore_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_group) | resource |
+| [aws_ssoadmin_instances.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_description"></a> [description](#input\_description) | The description to use for the IAM Identity Center user group | `string` | n/a | yes |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The name to use for the IAM Identity Center user group | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_group_id"></a> [group\_id](#output\_group\_id) | The id of the IAM Identity Center group |
+<!-- END_TF_DOCS -->

--- a/modules/iam-identity-center/iam-identity-center-group/v0.0.1/main.tf
+++ b/modules/iam-identity-center/iam-identity-center-group/v0.0.1/main.tf
@@ -1,0 +1,7 @@
+data "aws_ssoadmin_instances" "this" {}
+
+resource "aws_identitystore_group" "this" {
+  display_name      = var.display_name
+  description       = var.description
+  identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+}

--- a/modules/iam-identity-center/iam-identity-center-group/v0.0.1/outputs.tf
+++ b/modules/iam-identity-center/iam-identity-center-group/v0.0.1/outputs.tf
@@ -1,0 +1,4 @@
+output "group_id" {
+  value       = aws_identitystore_group.this.group_id
+  description = "The id of the IAM Identity Center group"
+}

--- a/modules/iam-identity-center/iam-identity-center-group/v0.0.1/provider.tf
+++ b/modules/iam-identity-center/iam-identity-center-group/v0.0.1/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/iam-identity-center/iam-identity-center-group/v0.0.1/variables.tf
+++ b/modules/iam-identity-center/iam-identity-center-group/v0.0.1/variables.tf
@@ -1,0 +1,9 @@
+variable "display_name" {
+  description = "The name to use for the IAM Identity Center user group"
+  type        = string
+}
+
+variable "description" {
+  description = "The description to use for the IAM Identity Center user group"
+  type        = string
+}

--- a/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/README.md
+++ b/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/README.md
@@ -1,0 +1,41 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ssoadmin_managed_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
+| [aws_ssoadmin_permission_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
+| [aws_ssoadmin_instances.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_description"></a> [description](#input\_description) | The description of the permission set | `string` | n/a | yes |
+| <a name="input_managed_policy_arns"></a> [managed\_policy\_arns](#input\_managed\_policy\_arns) | A map of the arns of the managed policies that you would like to associate with this permission set | `map(string)` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name to use for the permission set | `string` | n/a | yes |
+| <a name="input_session_duration"></a> [session\_duration](#input\_session\_duration) | The session duration associated with this permission set | `string` | `"PT4H"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_permission_set_arn"></a> [permission\_set\_arn](#output\_permission\_set\_arn) | The arn of the IAM Identity Center permission set |
+<!-- END_TF_DOCS -->

--- a/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/main.tf
+++ b/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/main.tf
@@ -1,0 +1,40 @@
+data "aws_ssoadmin_instances" "this" {}
+
+locals {
+  identity_store_arn = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+}
+
+resource "aws_ssoadmin_permission_set" "this" {
+  name             = var.name
+  description      = var.description
+  instance_arn     = local.identity_store_arn
+  session_duration = var.session_duration
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "this" {
+  for_each           = var.managed_policy_arns
+  instance_arn       = local.identity_store_arn
+  managed_policy_arn = each.value
+  permission_set_arn = aws_ssoadmin_permission_set.this.arn
+}
+
+# data "aws_iam_policy_document" "this" {
+#   statement {
+#     sid = "1"
+
+#     actions = [
+#       "s3:ListAllMyBuckets",
+#       "s3:GetBucketLocation",
+#     ]
+
+#     resources = [
+#       "arn:aws:s3:::*",
+#     ]
+#   }
+# }
+
+# resource "aws_ssoadmin_permission_set_inline_policy" "example" {
+#   inline_policy      = data.aws_iam_policy_document.this.json
+#   instance_arn       = local.identity_store_id
+#   permission_set_arn = aws_ssoadmin_permission_set.this.arn
+# }

--- a/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/outputs.tf
+++ b/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/outputs.tf
@@ -1,0 +1,4 @@
+output "permission_set_arn" {
+  value       = aws_ssoadmin_permission_set.this.arn
+  description = "The arn of the IAM Identity Center permission set"
+}

--- a/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/provider.tf
+++ b/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/variables.tf
+++ b/modules/iam-identity-center/iam-identity-center-permission-set/v0.0.1/variables.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "The name to use for the permission set"
+  type        = string
+}
+
+variable "description" {
+  description = "The description of the permission set"
+  type        = string
+}
+
+variable "session_duration" {
+  description = "The session duration associated with this permission set"
+  type        = string
+  default     = "PT4H"
+}
+
+variable "managed_policy_arns" {
+  description = "A map of the arns of the managed policies that you would like to associate with this permission set"
+  type        = map(string)
+}

--- a/modules/iam-identity-center/iam-identity-center-user/v0.0.1/README.md
+++ b/modules/iam-identity-center/iam-identity-center-user/v0.0.1/README.md
@@ -1,0 +1,39 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_identitystore_group_membership.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_group_membership) | resource |
+| [aws_identitystore_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/identitystore_user) | resource |
+| [aws_ssoadmin_instances.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_email"></a> [email](#input\_email) | The email of the user, this will be used as well to set the user\_name | `string` | n/a | yes |
+| <a name="input_family_name"></a> [family\_name](#input\_family\_name) | The last name of the user | `string` | n/a | yes |
+| <a name="input_given_name"></a> [given\_name](#input\_given\_name) | The first name of the user | `string` | n/a | yes |
+| <a name="input_groups"></a> [groups](#input\_groups) | the groups to which the user has to be added as a member | `map(string)` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/iam-identity-center/iam-identity-center-user/v0.0.1/main.tf
+++ b/modules/iam-identity-center/iam-identity-center-user/v0.0.1/main.tf
@@ -1,0 +1,27 @@
+data "aws_ssoadmin_instances" "this" {}
+
+locals {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.this.identity_store_ids)[0]
+}
+
+resource "aws_identitystore_user" "this" {
+  user_name    = var.email
+  display_name = "${var.given_name} ${var.family_name}"
+  name {
+    given_name  = var.given_name
+    family_name = var.family_name
+  }
+
+  emails {
+    value = var.email
+  }
+
+  identity_store_id = local.identity_store_id
+}
+
+resource "aws_identitystore_group_membership" "this" {
+  for_each          = var.groups
+  identity_store_id = local.identity_store_id
+  group_id          = each.value
+  member_id         = aws_identitystore_user.this.user_id
+}

--- a/modules/iam-identity-center/iam-identity-center-user/v0.0.1/provider.tf
+++ b/modules/iam-identity-center/iam-identity-center-user/v0.0.1/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/iam-identity-center/iam-identity-center-user/v0.0.1/variables.tf
+++ b/modules/iam-identity-center/iam-identity-center-user/v0.0.1/variables.tf
@@ -1,0 +1,19 @@
+variable "email" {
+  description = "The email of the user, this will be used as well to set the user_name"
+  type        = string
+}
+
+variable "given_name" {
+  description = "The first name of the user"
+  type        = string
+}
+
+variable "family_name" {
+  description = "The last name of the user"
+  type        = string
+}
+
+variable "groups" {
+  description = "the groups to which the user has to be added as a member"
+  type        = map(string)
+}


### PR DESCRIPTION
## Description
Terraform modules for the AWS IAM Identity Center service

## Motivation and Context
It adds new reusable terraform modules.

## Breaking Changes
na, it is a new module.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
I deployed and destroyed the example on the cn-devorg AWS organization
